### PR TITLE
Read from plan JSON and sanitize sensitive values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ workspace.init()
 results, apply_log = workspace.apply(auto_approve=True)
 ```
 
+There is also the capability to parse an existing plan JSON and create a plan object with the sensitive and unknown attributes sanitized
+in the output.
+
+```python
+  import json
+
+  plan_from_json = TerraformPlan("", "tests/terraform/plans/sensitive_plan.json", False)
+  for address, resource_change in plan_from_json.changes:
+    print(f"address: {address}\n")
+    print("before:\n")
+    print(json.dumps(resource_change.before_sanitized))
+    print("\nafter:\n")
+    print(json.dumps(resource_change.after_sanitized))
+```
 
 ### Installation
 

--- a/terraformer/conf/settings.py
+++ b/terraformer/conf/settings.py
@@ -4,3 +4,5 @@ from pydantic import BaseSettings
 class Settings(BaseSettings):
     project_name: str = "terraformer"
     debug: bool = False
+    plan_sensitive_data_replace_with: str = "(sensitive)"
+    plan_known_after_apply_replace_with: str = "(known after apply)"

--- a/terraformer/plan.py
+++ b/terraformer/plan.py
@@ -1,10 +1,12 @@
 import json
 import shutil
+from copy import deepcopy
 from logging import getLogger
 from typing import Any, Dict
 
 from .exceptions import TerraformRuntimeError, TerraformVersionError
 from .mixins import TerraformRun
+from .settings import settings
 
 logger = getLogger(__name__)
 
@@ -12,26 +14,34 @@ MODIFICATION_ACTIONS = ["update"]
 DELETION_ACTIONS = ["delete"]
 CREATE_ACTIONS = ["create"]
 
+SANITIZE_REPLACE_WITH = settings.plan_sensitive_data_replace_with
+KNOWN_AFTER_APPLY_REPLACE_WITH = settings.plan_known_after_apply_replace_with
+
 
 class TerraformPlan(TerraformRun):
     changes: Dict[str, Any]
     env: Dict[str, str]
 
-    def __init__(self, cwd, plan_path) -> None:
+    def __init__(self, cwd, plan_path, is_json=False) -> None:
         # confirm file exists
 
         self.cwd = cwd
         self.env = {}
         self.plan_path = plan_path
 
-        terraform_path = shutil.which("terraform")
-        command = [terraform_path, "show", "-json", plan_path]
-        results = self._subprocess_run(command)
+        if not is_json:
+            terraform_path = shutil.which("terraform")
+            command = [terraform_path, "show", "-json", plan_path]
+            results = self._subprocess_run(command)
 
-        if results.returncode != 0:
-            raise TerraformRuntimeError("Terraform plan failed", results)
+            if results.returncode != 0:
+                raise TerraformRuntimeError("Terraform plan failed", results)
 
-        plan_details = json.loads(results.stdout)
+            plan_details = json.loads(results.stdout)
+        else:
+            with open(plan_path) as plan_json:
+                plan_details = json.load(plan_json)
+
         self.raw_plan = plan_details
         self.terraform_version = plan_details["terraform_version"]
         self.format_version = plan_details["format_version"]
@@ -66,6 +76,17 @@ class TerraformChange:
         self.type = changeset["type"]
         self.actions = changeset["change"]["actions"]
 
+        # Capture the before, after changes and expose sanitized fields where the data is sensitive or unknown during plan.
+
+        self.before = changeset["change"]["before"]
+        self.before_sensitive = changeset["change"]["before_sensitive"]
+        self.after = changeset["change"]["after"]
+        self.after_sensitive = changeset["change"]["after_sensitive"]
+        self.after_unknown = changeset["change"]["after_unknown"]
+
+        self._sanitize_sensitive(SANITIZE_REPLACE_WITH)
+        self._sanitize_unknown(KNOWN_AFTER_APPLY_REPLACE_WITH)
+
     def will_delete(self):
         return len(list(set(self.actions) & set(DELETION_ACTIONS))) > 0
 
@@ -74,3 +95,40 @@ class TerraformChange:
 
     def will_create(self):
         return len(list(set(self.actions) & set(CREATE_ACTIONS))) > 0
+
+    # Sanitize the sensitive data and create a `sanitized` copy so that it can be used with reporting tools directly.
+    def _sanitize_sensitive(self, replace_with=SANITIZE_REPLACE_WITH):
+        self.before_sanitized = TerraformChange._sanitize_change_value(
+            deepcopy(self.before),
+            self.before_sensitive,
+            replace_with,  # send a copy so that the field itself isn't directly modified.
+        )
+        self.after_sanitized = TerraformChange._sanitize_change_value(
+            deepcopy(self.after), self.after_sensitive, replace_with
+        )
+
+    # Sanitize the data that can be known only after apply and add to the `sanitized` copy so that it can be used with reporting tools directly.
+    def _sanitize_unknown(self, replace_with=KNOWN_AFTER_APPLY_REPLACE_WITH):
+        self.after_sanitized = TerraformChange._sanitize_change_value(
+            deepcopy(self.after_sanitized), self.after_unknown, replace_with
+        )
+
+    def _sanitize_change_value(old_value, sanitizable, replace_with):
+        if type(old_value) == type([]) and type(sanitizable) == type([]):
+            for idx, sanitized in enumerate(sanitizable):
+                if sanitized == True:
+                    old_value[idx] = TerraformChange._sanitize_change_value(
+                        old_value[idx], sanitizable[idx], replace_with
+                    )
+
+        elif type(old_value) == type({}) and type(sanitizable) == type({}):
+            for key, value in sanitizable.items():
+                if value:
+                    old_value[key] = TerraformChange._sanitize_change_value(
+                        old_value.get(key), sanitizable.get(key), replace_with
+                    )
+
+        if sanitizable == True:
+            return replace_with
+
+        return old_value

--- a/tests/terraform/plans/sensitive_plan.json
+++ b/tests/terraform/plans/sensitive_plan.json
@@ -1,0 +1,31 @@
+{
+  "format_version": "1.1",
+  "terraform_version": "1.3.0",
+  "resource_changes": [
+    {
+      "address": "test",
+      "type": "test_resource",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "nested_property": {
+            "sensitive_value": "secure_string"
+          },
+          "generated_value": null
+        },
+        "after_unknown": {
+          "generated_value": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "nested_property": {
+            "sensitive_value": true
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -2,6 +2,9 @@ from pathlib import Path
 
 import pytest
 
+from terraformer import plan as plan_module
+from terraformer.plan import TerraformPlan
+
 PLAN_FILE = Path(__file__).parent.absolute() / "terraform" / "plans" / "test.plan"
 
 
@@ -19,8 +22,37 @@ def test_load(plan):
 
 
 def test_reload(plan):
-    plan._parse_changes([{"address": "1", "type": "test", "change": {"actions": ["delete"]}}])
+    plan._parse_changes(
+        [
+            {
+                "address": "1",
+                "type": "test",
+                "change": {
+                    "actions": ["delete"],
+                    "before": {"triggers": {"bundle_url": ""}},
+                    "after": None,
+                    "after_unknown": {"id": False, "triggers": {}},
+                    "before_sensitive": False,
+                    "after_sensitive": {"triggers": {}},
+                },
+            }
+        ]
+    )
     assert plan.format_version == "1.1"
     assert plan.deletions == 1, "Deleting 1 resources."
     assert plan.modifications == 0, "Nothing to modify."
     assert plan.creations == 7, "Creating 7 resources."
+
+
+def test_plan_json():
+    plan_from_json = TerraformPlan(cwd="", plan_path="tests/terraform/plans/sensitive_plan.json", is_json=True)
+    assert plan_from_json.deletions == 0, "Nothing to delete."
+    assert plan_from_json.creations == 1, "Creating 1 resource."
+    assert (
+        plan_from_json.changes["test"].after_sanitized.get("nested_property").get("sensitive_value")
+        == plan_module.SANITIZE_REPLACE_WITH
+    )
+    assert (
+        plan_from_json.changes["test"].after_sanitized.get("generated_value")
+        == plan_module.KNOWN_AFTER_APPLY_REPLACE_WITH
+    )


### PR DESCRIPTION
- If the plan is already generated, use the JSON output to populate the changeset. This enables terraformer to be embedded in tooling where plan is generated at another layer, and frees up the need to be version specific. This is especially true for CI/CD pipelines where the containers for terraform operations can be decoupled from plan inspection for diff generation, cost difference calculations etc.
- Add tests to validate the sanitization.
- Updated documentation.